### PR TITLE
refactor: centralize job loader script

### DIFF
--- a/_layouts/jobdesc.html
+++ b/_layouts/jobdesc.html
@@ -25,9 +25,15 @@
     <!-- Job Loader Script (job- prefixli id’lerle tamamen uyumlu) -->
     <script>
     document.addEventListener('DOMContentLoaded', function () {
-      const params = new URLSearchParams(window.location.search);
-      const slug = params.get('slug');
-      if (!slug) return;
+        const params = new URLSearchParams(window.location.search);
+        const slug = params.get('slug');
+        if (!slug) {
+          const nf = document.getElementById('job-notfound');
+          if (nf) nf.style.display = 'block';
+          const single = document.querySelector('.job-single');
+          if (single) single.style.display = 'none';
+          return;
+        }
 
       // Dil kontrolü → doğru JSON yolunu seç
       const jsonPath = '{{ page.lang }}' === 'tr'
@@ -56,10 +62,16 @@
           const locationHead = document.getElementById('job-location-head');
           if (locationHead) locationHead.textContent = job.location || '';
 
-          const typeHead = document.getElementById('job-type-head');
-          if (typeHead) typeHead.textContent = job.type || '';
+            const typeHead = document.getElementById('job-type-head');
+            if (typeHead) typeHead.textContent = job.type || '';
 
-          // Markdown içeriğini çek ve göster
+            const header = document.getElementById('article-masthead');
+            if (header && job.jobimg) {
+              const imgUrl = job.jobimg.startsWith('/') ? '{{ site.baseurl }}' + job.jobimg : job.jobimg;
+              header.style.backgroundImage = `url('${imgUrl}')`;
+            }
+
+            // Markdown içeriğini çek ve göster
           if (job.url) {
             const mdUrl = '{{ site.baseurl }}' + job.url;
             fetch(mdUrl)

--- a/career/tr/vacancies.html
+++ b/career/tr/vacancies.html
@@ -27,68 +27,6 @@ description: GreenAiriva kariyer fırsatları için detaylı iş ilanı açıkla
   </div>
 </main>
 
-<!-- İş İlanı Yükleyici Script -->
-<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-<script>
-document.addEventListener('DOMContentLoaded', function () {
-  const params = new URLSearchParams(window.location.search);
-  const slug = params.get('slug');
-
-  if (!slug) {
-    document.getElementById('job-notfound').style.display = 'block';
-    return;
-  }
-
-  const jsonUrl = '{{ site.baseurl }}/career/tr/jobs.json';
-
-  fetch(jsonUrl)
-    .then(res => {
-      if (!res.ok) throw new Error("Jobs JSON yüklenemedi: " + res.status);
-      return res.json();
-    })
-    .then(jobs => {
-      const job = jobs.find(j => (j.slug || '').toLowerCase() === slug.toLowerCase());
-      if (!job) {
-        document.getElementById('job-notfound').style.display = 'block';
-        return;
-      }
-
-      // Başlık ve meta bilgileri doldur
-      document.getElementById('job-title-head').textContent = job.title || '';
-      document.getElementById('job-location-head').textContent = job.location || '';
-      document.getElementById('job-type-head').textContent = job.type || '';
-
-      const header = document.getElementById('article-masthead');
-      if (job.jobimg) {
-         const imgUrl = job.jobimg.startsWith('/') ? '{{ site.baseurl }}' + job.jobimg : job.jobimg;
-         header.style.backgroundImage = `url('${imgUrl}')`;
-       }
-
-      // Markdown içeriğini çek
-      const mdUrl = '{{ site.baseurl }}' + job.url;
-
-      fetch(mdUrl)
-        .then(res => {
-          if (!res.ok) throw new Error('Markdown bulunamadı: ' + res.status);
-          return res.text();
-        })
-        .then(md => {
-          if (window.marked) {
-            document.getElementById('job-content').innerHTML = marked.parse(md);
-          } else {
-            document.getElementById('job-content').textContent = md;
-          }
-        })
-        .catch(err => {
-          document.getElementById('job-notfound').style.display = 'block';
-        });
-    })
-    .catch(err => {
-      document.getElementById('job-notfound').style.display = 'block';
-    });
-});
-</script>
-
 <!-- Navbar ile çakışmayı önlemek için ek stil -->
 <style>
 .job-header {

--- a/career/vacancies.html
+++ b/career/vacancies.html
@@ -27,68 +27,6 @@ description: Detailed job description for GreenAiriva career opportunities.
   </div>
 </main>
 
-<!-- Job Loader Script -->
-<script>
-document.addEventListener('DOMContentLoaded', function () {
-  const params = new URLSearchParams(window.location.search);
-  const slug = params.get('slug');
-  if (!slug) {
-    document.getElementById('job-notfound').style.display = 'block';
-    return;
-  }
-
-  const jsonUrl = '{{ site.baseurl }}/career/jobs.json';
-
-  fetch(jsonUrl)
-    .then(res => {
-      if (!res.ok) throw new Error("Jobs JSON yüklenemedi: " + res.status);
-      return res.json();
-    })
-    .then(jobs => {
-      const job = jobs.find(j => (j.slug || '').toLowerCase() === slug.toLowerCase());
-      if (!job) {
-        document.getElementById('job-notfound').style.display = 'block';
-        return;
-      }
-
-      // Fill in the job details
-      document.getElementById('job-title-head').textContent = job.title || '';
-      document.getElementById('job-location-head').textContent = job.location || '';
-      document.getElementById('job-type-head').textContent = job.type || '';
-
-      const header = document.getElementById('article-masthead');
-      if (job.jobimg) {
-        const imgUrl = job.jobimg.startsWith('/') ? '{{ site.baseurl }}' + job.jobimg : job.jobimg;
-        header.style.backgroundImage = `url('${imgUrl}')`;
-      }
-
-      // Fetch and render markdown job description
-      const mdUrl = '{{ site.baseurl }}' + job.url;
-      fetch(mdUrl)
-        .then(res => {
-          if (!res.ok) throw new Error('Markdown bulunamadı: ' + res.status);
-          return res.text();
-        })
-        .then(md => {
-          if (window.marked) {
-            document.getElementById('job-content').innerHTML = marked.parse(md);
-          } else {
-            document.getElementById('job-content').textContent = md;
-          }
-        })
-        .catch(err => {
-          document.getElementById('job-notfound').style.display = 'block';
-        });
-    })
-    .catch(err => {
-      document.getElementById('job-notfound').style.display = 'block';
-    });
-});
-</script>
-
-<!-- Markdown Parser -->
-<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-
 <!-- Extra CSS to prevent navbar overlap -->
 <style>
 .job-header {


### PR DESCRIPTION
## Summary
- remove inline job scripts from vacancy pages
- expand jobdesc layout script to handle missing slugs and header images

## Testing
- `node - <<'NODE' ...>`
- `node - <<'NODE' ...>`

------
https://chatgpt.com/codex/tasks/task_e_689ca797d8ac832e980d98600de15bd7