### PR TITLE
Add bilingual career application pages with validation

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -29,6 +29,9 @@
           <a class="nav-link" href="{{ site.baseurl }}/career/">Career</a>
         </li>
         <li class="nav-item">
+          <a class="nav-link" href="{{ site.baseurl }}/career/apply.html">Apply</a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" id="scrollToContact" href="#contact">Contact</a>
         </li>
         <!-- Language Switch -->

--- a/_includes/header_tr.html
+++ b/_includes/header_tr.html
@@ -27,6 +27,9 @@
           <a class="nav-link" href="{{ site.baseurl }}/tr/career/">Kariyer</a>
         </li>
         <li class="nav-item">
+          <a class="nav-link" href="{{ site.baseurl }}/career/tr/apply.html">Başvuru</a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" id="scrollToContact" href="#contact">İletişim</a>
         </li>
         <!-- Language Switch -->

--- a/career/apply.html
+++ b/career/apply.html
@@ -1,0 +1,138 @@
+---
+layout: default
+lang: en
+title: Application – GreenAiriva Careers
+description: Apply to GreenAiriva and help build solar-powered urban air purification technology.
+---
+
+<main class="container my-5">
+  <header class="mb-4 text-center">
+    <h1 class="fw-bold">GreenAiriva Application</h1>
+    <p class="text-muted">Apply for your desired role. Upload your CV and any relevant project documents.</p>
+  </header>
+
+  <form id="career-apply-form" class="ga-form"
+        action="__TODO_FORMSPREE_ENDPOINT__" method="POST" enctype="multipart/form-data" novalidate>
+    <!-- Anti-spam (honeypot) -->
+    <input type="text" name="company" id="hp-company" class="visually-hidden" tabindex="-1" autocomplete="off" aria-hidden="true">
+
+    <!-- Position info (filled from slug, readonly) -->
+    <div class="ga-form__group">
+      <label for="position" class="form-label">Position</label>
+      <input type="text" id="position" name="position" class="form-control" placeholder="Loading position..." readonly>
+      <input type="hidden" id="position_slug" name="position_slug">
+      <small class="text-muted">This field auto-fills based on the job slug in the URL.</small>
+      <small class="ga-form__error" id="err-position"></small>
+    </div>
+
+    <!-- Applicant basics -->
+    <div class="ga-form__grid">
+      <div class="ga-form__group">
+        <label for="full_name" class="form-label">Full Name<span class="text-danger">*</span></label>
+        <input id="full_name" name="full_name" type="text" class="form-control" required>
+        <small class="ga-form__error" id="err-full_name"></small>
+      </div>
+
+      <div class="ga-form__group">
+        <label for="email" class="form-label">Email<span class="text-danger">*</span></label>
+        <input id="email" name="email" type="email" class="form-control" required>
+        <small class="ga-form__error" id="err-email"></small>
+      </div>
+
+      <div class="ga-form__group">
+        <label for="phone" class="form-label">Phone</label>
+        <input id="phone" name="phone" type="tel" class="form-control" placeholder="+90 5xx xxx xx xx">
+        <small class="ga-form__error" id="err-phone"></small>
+      </div>
+
+      <div class="ga-form__group">
+        <label for="location" class="form-label">Location (City/Country)</label>
+        <input id="location" name="location" type="text" class="form-control" placeholder="Ankara, Turkey">
+      </div>
+    </div>
+
+    <div class="ga-form__grid">
+      <div class="ga-form__group">
+        <label for="linkedin" class="form-label">LinkedIn (optional)</label>
+        <input id="linkedin" name="linkedin" type="url" class="form-control" placeholder="https://www.linkedin.com/in/...">
+        <small class="ga-form__error" id="err-linkedin"></small>
+      </div>
+
+      <div class="ga-form__group">
+        <label for="portfolio" class="form-label">GitHub/Portfolio (optional)</label>
+        <input id="portfolio" name="portfolio" type="url" class="form-control" placeholder="https://github.com/...">
+        <small class="ga-form__error" id="err-portfolio"></small>
+      </div>
+    </div>
+
+    <div class="ga-form__grid">
+      <div class="ga-form__group">
+        <label for="availability" class="form-label">Availability (When can you start?)</label>
+        <input id="availability" name="availability" type="text" class="form-control" placeholder="Within 2 weeks / specific date">
+      </div>
+
+      <div class="ga-form__group">
+        <label for="salary" class="form-label">Expected Salary (gross)</label>
+        <input id="salary" name="salary" type="text" class="form-control" placeholder="e.g., 45,000 TRY/month">
+      </div>
+    </div>
+
+    <div class="ga-form__group">
+      <label for="cover_letter" class="form-label">Cover Letter</label>
+      <textarea id="cover_letter" name="cover_letter" class="form-control" maxlength="2000" placeholder="Briefly share your motivation (≤ 2000 characters)"></textarea>
+      <small class="ga-form__error" id="err-cover_letter"></small>
+    </div>
+
+    <!-- Role-specific blocks (injected via JS) -->
+    <section id="role-specific" class="ga-form__role mt-4">
+      <!-- JS will inject content (see js/apply.js) -->
+    </section>
+
+    <!-- File upload -->
+    <fieldset class="ga-form__fieldset mt-4">
+      <legend class="fw-semibold">Documents</legend>
+
+      <div class="ga-form__group">
+        <label for="cv" class="form-label">CV / Résumé (PDF/DOC/DOCX)<span class="text-danger">*</span></label>
+        <input id="cv" name="cv" type="file" class="form-control" accept=".pdf,.doc,.docx" required>
+        <small class="text-muted">Single file, max 5 MB.</small>
+        <small class="ga-form__error" id="err-cv"></small>
+      </div>
+
+      <div class="ga-form__group">
+        <label for="attachments" class="form-label">Additional Files / Projects (optional)</label>
+        <input id="attachments" name="attachments" type="file" class="form-control" multiple
+               accept=".pdf,.zip,.png,.jpg,.jpeg,.ppt,.pptx,.xlsx,.csv,.txt,.md">
+        <small class="text-muted">Total max 20 MB. Accepted formats: PDF, ZIP, images, presentation/sample files.</small>
+        <div class="ga-upload-list" id="upload-list"></div>
+        <div class="progress mt-2 d-none" id="upload-progress"><div class="progress-bar" style="width:0%"></div></div>
+        <small class="ga-form__error" id="err-attachments"></small>
+      </div>
+    </fieldset>
+
+    <!-- Consent -->
+    <div class="ga-form__group mt-3">
+      <div class="form-check">
+        <input class="form-check-input" type="checkbox" value="1" id="consent" name="consent" required>
+        <label class="form-check-label" for="consent">
+          I consent to the processing of my personal data for recruitment in line with privacy regulations.
+        </label>
+      </div>
+      <small class="ga-form__error" id="err-consent"></small>
+      <p class="mt-2"><a href="{{ site.baseurl }}/privacy/" class="link-primary">Privacy Notice</a></p>
+    </div>
+
+    <!-- Suggested hidden fields for Formspree -->
+    <input type="hidden" name="_subject" value="GreenAiriva Application">
+    <input type="hidden" name="_language" value="en">
+    <input type="hidden" name="_page_url" id="page_url">
+
+    <!-- Submit -->
+    <div class="mt-4">
+      <button type="submit" class="btn btn-primary btn-lg">Submit Application</button>
+      <div class="form-alert mt-3" id="form-alert" role="status" aria-live="polite"></div>
+    </div>
+  </form>
+</main>
+
+<script src="{{ site.baseurl }}/js/apply.js" defer></script>

--- a/career/tr/apply.html
+++ b/career/tr/apply.html
@@ -1,0 +1,138 @@
+---
+layout: default
+lang: tr
+title: Başvuru – GreenAiriva Kariyer
+description: GreenAiriva’ya başvurun; güneş enerjili kentsel hava arıtma teknolojisini birlikte geliştirelim.
+---
+
+<main class="container my-5">
+  <header class="mb-4 text-center">
+    <h1 class="fw-bold">GreenAiriva Başvuru</h1>
+    <p class="text-muted">İlgilendiğiniz pozisyona başvurun. CV’nizi ve varsa ilgili proje belgelerinizi yükleyin.</p>
+  </header>
+
+  <form id="career-apply-form" class="ga-form" 
+        action="__TODO_FORMSPREE_ENDPOINT__" method="POST" enctype="multipart/form-data" novalidate>
+    <!-- Anti-spam (honeypot) -->
+    <input type="text" name="company" id="hp-company" class="visually-hidden" tabindex="-1" autocomplete="off" aria-hidden="true">
+
+    <!-- İlan/pozisyon bilgisi (slug'tan gelecek, readonly) -->
+    <div class="ga-form__group">
+      <label for="position" class="form-label">Pozisyon</label>
+      <input type="text" id="position" name="position" class="form-control" placeholder="Pozisyon yükleniyor..." readonly>
+      <input type="hidden" id="position_slug" name="position_slug">
+      <small class="text-muted">Bu alan ilan sayfasındaki slug’a göre otomatik dolar.</small>
+      <small class="ga-form__error" id="err-position"></small>
+    </div>
+
+    <!-- Başvuran temel bilgileri -->
+    <div class="ga-form__grid">
+      <div class="ga-form__group">
+        <label for="full_name" class="form-label">Ad Soyad<span class="text-danger">*</span></label>
+        <input id="full_name" name="full_name" type="text" class="form-control" required>
+        <small class="ga-form__error" id="err-full_name"></small>
+      </div>
+
+      <div class="ga-form__group">
+        <label for="email" class="form-label">E-posta<span class="text-danger">*</span></label>
+        <input id="email" name="email" type="email" class="form-control" required>
+        <small class="ga-form__error" id="err-email"></small>
+      </div>
+
+      <div class="ga-form__group">
+        <label for="phone" class="form-label">Telefon</label>
+        <input id="phone" name="phone" type="tel" class="form-control" placeholder="+90 5xx xxx xx xx">
+        <small class="ga-form__error" id="err-phone"></small>
+      </div>
+
+      <div class="ga-form__group">
+        <label for="location" class="form-label">Konum (Şehir/Ülke)</label>
+        <input id="location" name="location" type="text" class="form-control" placeholder="Ankara, Türkiye">
+      </div>
+    </div>
+
+    <div class="ga-form__grid">
+      <div class="ga-form__group">
+        <label for="linkedin" class="form-label">LinkedIn (opsiyonel)</label>
+        <input id="linkedin" name="linkedin" type="url" class="form-control" placeholder="https://www.linkedin.com/in/...">
+        <small class="ga-form__error" id="err-linkedin"></small>
+      </div>
+
+      <div class="ga-form__group">
+        <label for="portfolio" class="form-label">GitHub/Portföy (opsiyonel)</label>
+        <input id="portfolio" name="portfolio" type="url" class="form-control" placeholder="https://github.com/...">
+        <small class="ga-form__error" id="err-portfolio"></small>
+      </div>
+    </div>
+
+    <div class="ga-form__grid">
+      <div class="ga-form__group">
+        <label for="availability" class="form-label">Uygunluk (Ne zaman başlayabilirsiniz?)</label>
+        <input id="availability" name="availability" type="text" class="form-control" placeholder="2 hafta içinde / belirli tarih">
+      </div>
+
+      <div class="ga-form__group">
+        <label for="salary" class="form-label">Beklenen maaş (brüt)</label>
+        <input id="salary" name="salary" type="text" class="form-control" placeholder="Örn: 45.000 TL/ay">
+      </div>
+    </div>
+
+    <div class="ga-form__group">
+      <label for="cover_letter" class="form-label">Ön Yazı</label>
+      <textarea id="cover_letter" name="cover_letter" class="form-control" maxlength="2000" placeholder="Motivasyonunuzu kısaca anlatın (≤ 2000 karakter)"></textarea>
+      <small class="ga-form__error" id="err-cover_letter"></small>
+    </div>
+
+    <!-- ROL ÖZEL BLOKLAR (slug'a göre gösterilecek) -->
+    <section id="role-specific" class="ga-form__role mt-4">
+      <!-- JS dinamik olarak içeriği inject edecek (bkz. js/apply.js) -->
+    </section>
+
+    <!-- Dosya yükleme -->
+    <fieldset class="ga-form__fieldset mt-4">
+      <legend class="fw-semibold">Belgeler</legend>
+
+      <div class="ga-form__group">
+        <label for="cv" class="form-label">CV / Özgeçmiş (PDF/DOC/DOCX)<span class="text-danger">*</span></label>
+        <input id="cv" name="cv" type="file" class="form-control" accept=".pdf,.doc,.docx" required>
+        <small class="text-muted">Tek dosya, maks. 5 MB.</small>
+        <small class="ga-form__error" id="err-cv"></small>
+      </div>
+
+      <div class="ga-form__group">
+        <label for="attachments" class="form-label">Ek Belgeler / Projeler (opsiyonel)</label>
+        <input id="attachments" name="attachments" type="file" class="form-control" multiple 
+               accept=".pdf,.zip,.png,.jpg,.jpeg,.ppt,.pptx,.xlsx,.csv,.txt,.md">
+        <small class="text-muted">Toplam maks. 20 MB. Uygun formatlar: PDF, ZIP, görseller, sunum/dosya örnekleri.</small>
+        <div class="ga-upload-list" id="upload-list"></div>
+        <div class="progress mt-2 d-none" id="upload-progress"><div class="progress-bar" style="width:0%"></div></div>
+        <small class="ga-form__error" id="err-attachments"></small>
+      </div>
+    </fieldset>
+
+    <!-- KVKK / Onay -->
+    <div class="ga-form__group mt-3">
+      <div class="form-check">
+        <input class="form-check-input" type="checkbox" value="1" id="consent" name="consent" required>
+        <label class="form-check-label" for="consent">
+          KVKK kapsamında işe alım amacıyla kişisel verilerimin işlenmesine onay veriyorum.
+        </label>
+      </div>
+      <small class="ga-form__error" id="err-consent"></small>
+      <p class="mt-2"><a href="{{ site.baseurl }}/privacy/" class="link-primary">Aydınlatma Metni</a></p>
+    </div>
+
+    <!-- Gizli alanlar (Formspree için öneri) -->
+    <input type="hidden" name="_subject" value="GreenAiriva Başvuru">
+    <input type="hidden" name="_language" value="tr">
+    <input type="hidden" name="_page_url" id="page_url">
+
+    <!-- GÖNDER -->
+    <div class="mt-4">
+      <button type="submit" class="btn btn-primary btn-lg">Başvuruyu Gönder</button>
+      <div class="form-alert mt-3" id="form-alert" role="status" aria-live="polite"></div>
+    </div>
+  </form>
+</main>
+
+<script src="{{ site.baseurl }}/js/apply.js" defer></script>

--- a/career/tr/vacancies.html
+++ b/career/tr/vacancies.html
@@ -28,6 +28,23 @@ alternate_url: /career/vacancies.html
   </div>
 </main>
 
+<div class="text-center my-4">
+  <a id="applyButton" class="btn btn-primary btn-lg">Bu ilana başvur</a>
+</div>
+<script>
+  (function(){
+    const p = new URLSearchParams(location.search);
+    const slug = p.get('slug') || '';
+    var applyUrl = '{{ site.baseurl }}/career/tr/apply.html';
+    if (document.documentElement.lang === 'en') applyUrl = '{{ site.baseurl }}/career/apply.html';
+    var btn = document.getElementById('applyButton');
+    if (btn) {
+      btn.href = applyUrl + (slug ? ('?slug=' + encodeURIComponent(slug)) : '');
+    }
+  })();
+</script>
+
+
 <!-- Navbar ile çakışmayı önlemek için ek stil -->
 <style>
 .job-header {

--- a/career/vacancies.html
+++ b/career/vacancies.html
@@ -28,6 +28,23 @@ alternate_url: /career/tr/vacancies.html
   </div>
 </main>
 
+<div class="text-center my-4">
+  <a id="applyButton" class="btn btn-primary btn-lg">Apply to this job</a>
+</div>
+<script>
+  (function(){
+    const p = new URLSearchParams(location.search);
+    const slug = p.get('slug') || '';
+    var applyUrl = '{{ site.baseurl }}/career/apply.html';
+    if (document.documentElement.lang === 'tr') applyUrl = '{{ site.baseurl }}/career/tr/apply.html';
+    var btn = document.getElementById('applyButton');
+    if (btn) {
+      btn.href = applyUrl + (slug ? ('?slug=' + encodeURIComponent(slug)) : '');
+    }
+  })();
+</script>
+
+
 <!-- Extra CSS to prevent navbar overlap -->
 <style>
 .job-header {

--- a/css/styles.css
+++ b/css/styles.css
@@ -2185,3 +2185,19 @@ h1, h2, h3, h4, h5 {
 /* =========================================================
    07. Print
    ========================================================= */
+
+/* === Careers Apply Form (GreenAiriva) === */
+.ga-form { max-width: 980px; margin: 0 auto; }
+.ga-form__grid { display: grid; grid-template-columns: 1fr; gap: 16px; }
+.ga-form__group { margin-bottom: 16px; }
+.ga-form__error { color: #dc3545; font-size: .9rem; display: block; min-height: 1.2em; }
+
+@media (min-width: 641px) {
+  .ga-form__grid { grid-template-columns: 1fr 1fr; }
+}
+.visually-hidden {
+  position: absolute !important; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden;
+  clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+}
+.ga-upload-list { font-size: .95rem; margin-top: .25rem; }
+.progress .progress-bar { background-color: var(--bs-warning, #ffc800); }

--- a/js/apply.js
+++ b/js/apply.js
@@ -1,0 +1,355 @@
+(function () {
+  'use strict';
+
+  const doc = document;
+  const qs = (selector, parent = doc) => parent.querySelector(selector);
+  const form = qs('#career-apply-form');
+  if (!form) return;
+
+  const lang = doc.documentElement.getAttribute('lang') || 'tr';
+
+  const stylesLink = doc.querySelector('link[href*="/css/styles.css"]');
+  let baseUrl = '';
+  if (stylesLink) {
+    const href = stylesLink.getAttribute('href') || '';
+    const prefix = href.split('/css/styles.css')[0];
+    if (prefix && prefix !== '.') {
+      baseUrl = prefix;
+    }
+  }
+  if (baseUrl.endsWith('/')) {
+    baseUrl = baseUrl.slice(0, -1);
+  }
+
+  const jobsPath = lang === 'tr' ? '/career/tr/jobs.json' : '/career/jobs.json';
+  const jobsUrl = `${baseUrl}${jobsPath}` || jobsPath;
+
+  const params = new URLSearchParams(window.location.search);
+  const rawSlug = params.get('slug') || '';
+  const slugLower = rawSlug.toLowerCase();
+
+  const slugAlias = {
+    'donanim-prototip-gelistirme-muhendisi': 'hardware-prototype-development-engineer',
+    'elektrik-elektronik-iot-muhendisi': 'electronics-iot-engineer',
+    'veri-analisti': 'data-analyst',
+    'kimyager-malzeme-uzmani': 'chemist-material-specialist',
+    'is-gelistirme-sorumlusu': 'business-developer'
+  };
+  const effectiveSlug = slugAlias[slugLower] || slugLower;
+
+  const pageUrlInput = qs('#page_url');
+  if (pageUrlInput) {
+    pageUrlInput.value = window.location.href;
+  }
+
+  const positionInput = qs('#position');
+  const positionSlugInput = qs('#position_slug');
+  const alertBox = qs('#form-alert');
+
+  if (positionSlugInput) {
+    positionSlugInput.value = rawSlug || '';
+  }
+
+  const translate = (tr, en) => (lang === 'tr' ? tr : en);
+
+  fetch(jobsUrl, { cache: 'no-store' })
+    .then((res) => {
+      if (!res.ok) throw new Error('network');
+      return res.json();
+    })
+    .then((data) => {
+      let list = [];
+      if (Array.isArray(data)) {
+        list = data;
+      } else if (data && Array.isArray(data.jobs)) {
+        list = data.jobs;
+      }
+      const job = list.find((item) => (item.slug || '').toLowerCase() === effectiveSlug) || null;
+      if (positionSlugInput && job && !rawSlug) {
+        positionSlugInput.value = job.slug || '';
+      }
+      if (positionInput) {
+        const title = job && job.title ? job.title : translate('(İlan başlığı bulunamadı)', '(Job not found)');
+        positionInput.value = title;
+      }
+      renderRoleBlock(rawSlug || (job && job.slug) || '', lang);
+    })
+    .catch(() => {
+      if (positionInput) {
+        positionInput.value = translate('(İlan verisi yüklenemedi)', '(Failed to load job data)');
+      }
+      renderRoleBlock(rawSlug, lang);
+    });
+
+  function renderRoleBlock(slug, langCode) {
+    const host = qs('#role-specific');
+    if (!host) return;
+    const t = (tr, en) => (langCode === 'tr' ? tr : en);
+    let html = '';
+    const slugKey = (slug || '').toLowerCase();
+
+    switch (slugKey) {
+      case 'hardware-prototype-development-engineer':
+      case 'donanim-prototip-gelistirme-muhendisi':
+        html = `
+          <h2 class="h5 mb-3">${t('Mekanik / Prototip Bilgileri', 'Mechanical / Prototype Details')}</h2>
+          <div class="ga-form__grid">
+            <div class="ga-form__group">
+              <label class="form-label" for="cad_tools">${t('Kullandığınız CAD/CAE araçları', 'CAD/CAE tools used')}</label>
+              <input id="cad_tools" name="cad_tools" type="text" class="form-control" placeholder="Inventor, SolidWorks, ANSYS...">
+            </div>
+            <div class="ga-form__group">
+              <label class="form-label" for="proto_exp">${t('Prototip Deneyimi', 'Prototype Experience')}</label>
+              <textarea id="proto_exp" name="proto_exp" class="form-control" maxlength="1200"></textarea>
+            </div>
+          </div>`;
+        break;
+
+      case 'electronics-iot-engineer':
+      case 'elektrik-elektronik-iot-muhendisi':
+        html = `
+          <h2 class="h5 mb-3">${t('Elektronik & IoT', 'Electronics & IoT')}</h2>
+          <div class="ga-form__grid">
+            <div class="ga-form__group">
+              <label class="form-label" for="pcb_tools">PCB</label>
+              <input id="pcb_tools" name="pcb_tools" type="text" class="form-control" placeholder="KiCad, Altium, Eagle...">
+            </div>
+            <div class="ga-form__group">
+              <label class="form-label" for="iot_stack">IoT</label>
+              <input id="iot_stack" name="iot_stack" type="text" class="form-control" placeholder="LoRa, MQTT, NB-IoT, Wi-Fi...">
+            </div>
+          </div>`;
+        break;
+
+      case 'data-analyst':
+      case 'veri-analisti':
+        html = `
+          <h2 class="h5 mb-3">${t('Yazılım & Veri', 'Software & Data')}</h2>
+          <div class="ga-form__grid">
+            <div class="ga-form__group">
+              <label class="form-label" for="stack">${t('Yığın / Diller', 'Stack / Languages')}</label>
+              <input id="stack" name="stack" type="text" class="form-control" placeholder="Python, JS/TS, SQL...">
+            </div>
+            <div class="ga-form__group">
+              <label class="form-label" for="db_api">${t('Veritabanı / API Deneyimi', 'Database / API Experience')}</label>
+              <textarea id="db_api" name="db_api" class="form-control" maxlength="1200"></textarea>
+            </div>
+          </div>`;
+        break;
+
+      case 'chemist-material-specialist':
+      case 'kimyager-malzeme-uzmani':
+        html = `
+          <h2 class="h5 mb-3">${t('Malzeme & Karakterizasyon', 'Materials & Characterization')}</h2>
+          <div class="ga-form__grid">
+            <div class="ga-form__group">
+              <label class="form-label" for="materials">${t('Malzemeler', 'Materials')}</label>
+              <input id="materials" name="materials" type="text" class="form-control" placeholder="MOF, COF, Zeolit, Aktif Karbon...">
+            </div>
+            <div class="ga-form__group">
+              <label class="form-label" for="methods">${t('Laboratuvar Teknikleri', 'Lab Techniques')}</label>
+              <input id="methods" name="methods" type="text" class="form-control" placeholder="XRD, BET, SEM, TGA, FTIR...">
+            </div>
+          </div>`;
+        break;
+
+      case 'business-developer':
+      case 'is-gelistirme-sorumlusu':
+        html = `
+          <h2 class="h5 mb-3">${t('İş Geliştirme', 'Business Development')}</h2>
+          <div class="ga-form__grid">
+            <div class="ga-form__group">
+              <label class="form-label" for="grants">${t('Hibe/Fon Tecrübeleri', 'Grants/Funding Experience')}</label>
+              <textarea id="grants" name="grants" class="form-control" maxlength="1200" placeholder="TÜBİTAK, Horizon, EIC..."></textarea>
+            </div>
+            <div class="ga-form__group">
+              <label class="form-label" for="pitch">${t('Kısa Pitch / Yaklaşım', 'Short Pitch / Approach')}</label>
+              <textarea id="pitch" name="pitch" class="form-control" maxlength="800"></textarea>
+            </div>
+          </div>`;
+        break;
+
+      default:
+        html = '';
+    }
+    host.innerHTML = html;
+  }
+
+  const err = (id, msg) => {
+    const el = qs(`#err-${id}`);
+    if (el) {
+      el.textContent = msg || '';
+    }
+  };
+
+  function clearErrors() {
+    ['position', 'full_name', 'email', 'phone', 'linkedin', 'portfolio', 'cv', 'attachments', 'cover_letter', 'consent'].forEach((key) => err(key, ''));
+    if (alertBox) {
+      alertBox.textContent = '';
+    }
+    if (uploadProgress) {
+      uploadProgress.classList.add('d-none');
+      const bar = uploadProgress.querySelector('.progress-bar');
+      if (bar) {
+        bar.style.width = '0%';
+      }
+    }
+  }
+
+  const MAX_CV = 5 * 1024 * 1024;
+  const MAX_ATTACH_SUM = 20 * 1024 * 1024;
+  const ATT_OK = /(\.)(pdf|zip|png|jpe?g|pptx?|xlsx|csv|txt|md)$/i;
+  const CV_OK = /(\.)(pdf|docx?)$/i;
+
+  const cvInput = qs('#cv');
+  const attachmentsInput = qs('#attachments');
+  const uploadList = qs('#upload-list');
+  const uploadProgress = qs('#upload-progress');
+
+  function sizeHuman(bytes) {
+    if (!bytes) return '0 MB';
+    return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+  }
+
+  function renderList(files) {
+    if (!uploadList) return;
+    uploadList.innerHTML = '';
+    if (!files || !files.length) return;
+    const ul = doc.createElement('ul');
+    ul.className = 'list-unstyled mb-0';
+    files.forEach((file) => {
+      const li = doc.createElement('li');
+      li.textContent = `${file.name} (${sizeHuman(file.size)})`;
+      ul.appendChild(li);
+    });
+    uploadList.appendChild(ul);
+  }
+
+  attachmentsInput?.addEventListener('change', () => {
+    renderList(Array.from(attachmentsInput.files || []));
+  });
+
+  form.addEventListener('submit', (event) => {
+    clearErrors();
+    let valid = true;
+
+    const honeypot = qs('#hp-company');
+    if (honeypot && honeypot.value) {
+      event.preventDefault();
+      return false;
+    }
+
+    const fullName = qs('#full_name')?.value.trim();
+    const email = qs('#email')?.value.trim();
+    const consent = qs('#consent')?.checked;
+    const coverLetter = qs('#cover_letter')?.value || '';
+    const linkedin = qs('#linkedin')?.value.trim();
+    const portfolio = qs('#portfolio')?.value.trim();
+
+    if (!positionInput || !positionInput.value.trim() || positionInput.value.startsWith('(') || /yükleniyor|loading/i.test(positionInput.value)) {
+      err('position', translate('Pozisyon doğrulanamadı.', 'Position could not be verified.'));
+      valid = false;
+    }
+
+    if (!fullName) {
+      err('full_name', translate('Zorunlu alan', 'Required'));
+      valid = false;
+    }
+
+    if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      err('email', translate('Geçerli e-posta girin', 'Enter a valid email'));
+      valid = false;
+    }
+
+    if (!consent) {
+      err('consent', translate('Onay gerekli', 'Consent required'));
+      valid = false;
+    }
+
+    if (linkedin) {
+      try {
+        const url = new URL(linkedin);
+        if (!/^https?:$/i.test(url.protocol)) {
+          throw new Error('invalid protocol');
+        }
+      } catch (error) {
+        err('linkedin', translate('Geçerli bir URL girin', 'Enter a valid URL'));
+        valid = false;
+      }
+    }
+
+    if (portfolio) {
+      try {
+        const url = new URL(portfolio);
+        if (!/^https?:$/i.test(url.protocol)) {
+          throw new Error('invalid protocol');
+        }
+      } catch (error) {
+        err('portfolio', translate('Geçerli bir URL girin', 'Enter a valid URL'));
+        valid = false;
+      }
+    }
+
+    if (coverLetter && coverLetter.length > 2000) {
+      err('cover_letter', translate('Ön yazı 2000 karakteri aşmamalı', 'Cover letter must be 2000 characters or less'));
+      valid = false;
+    }
+
+    const cvFile = cvInput?.files?.[0] || null;
+    if (!cvFile) {
+      err('cv', translate('CV gerekli', 'CV required'));
+      valid = false;
+    } else {
+      if (!CV_OK.test(cvFile.name)) {
+        err('cv', translate('CV dosya türü desteklenmiyor', 'Unsupported CV file type'));
+        valid = false;
+      }
+      if (cvFile.size > MAX_CV) {
+        err('cv', translate('CV boyutu 5 MB’ı aşamaz', 'CV must be ≤ 5 MB'));
+        valid = false;
+      }
+    }
+
+    let attachmentsTotal = 0;
+    let attachmentsBadType = false;
+    const attachmentFiles = Array.from(attachmentsInput?.files || []);
+    attachmentFiles.forEach((file) => {
+      attachmentsTotal += file.size;
+      if (!ATT_OK.test(file.name)) {
+        attachmentsBadType = true;
+      }
+    });
+
+    if (attachmentsTotal > MAX_ATTACH_SUM) {
+      err('attachments', translate('Toplam ek boyutu 20 MB’ı aşamaz', 'Total attachments must be ≤ 20 MB'));
+      valid = false;
+    }
+
+    if (attachmentsBadType) {
+      err('attachments', translate('Uygun olmayan dosya uzantısı var', 'Some attachments have unsupported types'));
+      valid = false;
+    }
+
+    if (!valid) {
+      event.preventDefault();
+      if (alertBox) {
+        alertBox.textContent = translate('Lütfen hataları düzeltin.', 'Please fix the errors.');
+      }
+      return false;
+    }
+
+    if (uploadProgress) {
+      uploadProgress.classList.remove('d-none');
+      const bar = uploadProgress.querySelector('.progress-bar');
+      if (bar) {
+        bar.style.width = '100%';
+      }
+    }
+
+    if (alertBox) {
+      alertBox.textContent = translate('Gönderiliyor...', 'Submitting...');
+    }
+
+    return true;
+  });
+})();


### PR DESCRIPTION
## Summary
- add English and Turkish career application pages with multilingual copy, conditional role sections, and Formspree-ready metadata
- introduce a shared apply.js that derives job info from slugs, renders role-specific questions, validates inputs, and manages attachment UX
- extend styles and navigation so headers link to the new forms and vacancy pages surface an apply call-to-action with slug propagation

## Testing
- bundle exec jekyll build *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68d17842db74832e8f01eb1f9ab70d5c