### PR TITLE
Create Separate Application Forms for Each Job

### DIFF
--- a/career/applications/apply1.html
+++ b/career/applications/apply1.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Donanım &amp; Prototip Geliştirme Mühendisi Başvuru Formu</title>
+</head>
+<body>
+  <main class="container my-5">
+    <header class="ga-form__group text-center">
+      <h1>Donanım &amp; Prototip Geliştirme Mühendisi</h1>
+      <p>GreenAiriva donanım geliştirme ekibine katılmak için bu formu eksiksiz doldurun.</p>
+    </header>
+
+    <form class="ga-form" novalidate>
+      <section class="ga-form__section">
+        <h2>Temel Bilgiler</h2>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="full_name">Ad Soyad<span class="text-danger">*</span></label>
+            <input id="full_name" name="full_name" type="text" required>
+          </div>
+          <div class="ga-form__group">
+            <label for="email">E-posta<span class="text-danger">*</span></label>
+            <input id="email" name="email" type="email" required>
+          </div>
+          <div class="ga-form__group">
+            <label for="phone">Telefon</label>
+            <input id="phone" name="phone" type="tel" placeholder="+90 5xx xxx xx xx">
+          </div>
+          <div class="ga-form__group">
+            <label for="location">Konum</label>
+            <input id="location" name="location" type="text" placeholder="Şehir, Ülke">
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Profesyonel Bilgiler</h2>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="linkedin">LinkedIn</label>
+            <input id="linkedin" name="linkedin" type="url" placeholder="https://www.linkedin.com/in/...">
+          </div>
+          <div class="ga-form__group">
+            <label for="portfolio">Portföy / GitHub</label>
+            <input id="portfolio" name="portfolio" type="url" placeholder="https://github.com/...">
+          </div>
+        </div>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="education_level">Eğitim Durumu</label>
+            <select id="education_level" name="education_level">
+              <option value="" selected disabled>Seçiniz</option>
+              <option value="lise">Lise</option>
+              <option value="on_lisans">Ön Lisans</option>
+              <option value="lisans">Lisans</option>
+              <option value="yuksek_lisans">Yüksek Lisans</option>
+              <option value="doktora">Doktora</option>
+            </select>
+          </div>
+          <div class="ga-form__group">
+            <label for="education_field">Mezuniyet Alanı</label>
+            <input id="education_field" name="education_field" type="text" placeholder="Bölüm">
+          </div>
+          <div class="ga-form__group">
+            <label for="graduation_year">Mezuniyet Yılı</label>
+            <input id="graduation_year" name="graduation_year" type="number" min="1950" max="2099" placeholder="2024">
+          </div>
+        </div>
+        <div class="ga-form__group">
+          <label for="experience_summary">İş Deneyimi</label>
+          <textarea id="experience_summary" name="experience_summary" rows="4" placeholder="Son pozisyonlarınızı ve görevlerinizi özetleyin."></textarea>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Teknik Yetenekler</h2>
+        <div class="ga-form__group">
+          <span class="d-block mb-2">Lütfen sahip olduğunuz yetenekleri seçiniz:</span>
+          <div class="ga-form__grid">
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="CAD"> CAD</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="Python"> Python</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="MATLAB"> MATLAB</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="PCB Design"> PCB Design</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="IoT Protokolleri"> IoT protokolleri</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="Diger"> Diğer</label>
+            </div>
+          </div>
+          <div class="ga-form__group">
+            <label for="skills_other">Diğer beceriler</label>
+            <input id="skills_other" name="skills_other" type="text" placeholder="Ek teknik yetenekler">
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Dil Yetenekleri</h2>
+        <div class="ga-form__group">
+          <label for="languages">Yabancı diller ve seviyeleri</label>
+          <input id="languages" name="languages" type="text" placeholder="Örn: İngilizce (C1), Almanca (B1)">
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Proje Deneyimleri</h2>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="project_one">Proje 1</label>
+            <textarea id="project_one" name="project_one" rows="4" placeholder="Proje kapsamı, rolünüz ve çıktılar"></textarea>
+          </div>
+          <div class="ga-form__group">
+            <label for="project_two">Proje 2</label>
+            <textarea id="project_two" name="project_two" rows="4" placeholder="Proje kapsamı, rolünüz ve çıktılar"></textarea>
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Kültürel &amp; Kişisel Sorular</h2>
+        <div class="ga-form__group">
+          <label for="why_greenairiva">GreenAiriva’yı neden tercih ediyorsunuz?</label>
+          <textarea id="why_greenairiva" name="why_greenairiva" rows="4"></textarea>
+        </div>
+        <div class="ga-form__group">
+          <label for="team_strength">Takım çalışmasında güçlü olduğunuz yön</label>
+          <textarea id="team_strength" name="team_strength" rows="3"></textarea>
+        </div>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="remote_fit">Uzaktan/Hibrit çalışmaya uygun musunuz?</label>
+            <input id="remote_fit" name="remote_fit" type="text" placeholder="Evet / Hayır ve açıklama">
+          </div>
+          <div class="ga-form__group">
+            <label for="travel">Seyahat engeliniz var mı?</label>
+            <input id="travel" name="travel" type="text" placeholder="Varsa detaylandırın">
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Referanslar</h2>
+        <div class="ga-form__group">
+          <h3>Referans 1</h3>
+          <div class="ga-form__grid">
+            <div class="ga-form__group">
+              <label for="ref1_name">Ad Soyad</label>
+              <input id="ref1_name" name="ref1_name" type="text">
+            </div>
+            <div class="ga-form__group">
+              <label for="ref1_relationship">İlişki</label>
+              <input id="ref1_relationship" name="ref1_relationship" type="text" placeholder="Örn: Eski Yönetici">
+            </div>
+            <div class="ga-form__group">
+              <label for="ref1_contact">İletişim</label>
+              <input id="ref1_contact" name="ref1_contact" type="text" placeholder="E-posta veya Telefon">
+            </div>
+          </div>
+        </div>
+        <div class="ga-form__group">
+          <h3>Referans 2</h3>
+          <div class="ga-form__grid">
+            <div class="ga-form__group">
+              <label for="ref2_name">Ad Soyad</label>
+              <input id="ref2_name" name="ref2_name" type="text">
+            </div>
+            <div class="ga-form__group">
+              <label for="ref2_relationship">İlişki</label>
+              <input id="ref2_relationship" name="ref2_relationship" type="text">
+            </div>
+            <div class="ga-form__group">
+              <label for="ref2_contact">İletişim</label>
+              <input id="ref2_contact" name="ref2_contact" type="text" placeholder="E-posta veya Telefon">
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Belgeler</h2>
+        <div class="ga-form__group">
+          <label for="cv">CV Yükleme<span class="text-danger">*</span></label>
+          <input id="cv" name="cv" type="file" required>
+        </div>
+        <div class="ga-form__group">
+          <label for="additional_documents">Ek belgeler / projeler</label>
+          <input id="additional_documents" name="additional_documents" type="file" multiple>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Onaylar</h2>
+        <div class="ga-form__group">
+          <label><input type="checkbox" name="kvkk" value="accepted" required> KVKK metnini okudum ve onaylıyorum.</label>
+        </div>
+        <div class="ga-form__group">
+          <label><input type="checkbox" name="email_opt_in" value="yes"> GreenAiriva bilgilendirme e-postası almak istiyorum.</label>
+        </div>
+      </section>
+    </form>
+  </main>
+</body>
+</html>

--- a/career/applications/apply2.html
+++ b/career/applications/apply2.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Elektrik-Elektronik &amp; IoT Mühendisi Başvuru Formu</title>
+</head>
+<body>
+  <main class="container my-5">
+    <header class="ga-form__group text-center">
+      <h1>Elektrik-Elektronik &amp; IoT Mühendisi</h1>
+      <p>GreenAiriva'nın elektrik-elektronik ve IoT çözümlerine katkı sağlamak için bu formu doldurun.</p>
+    </header>
+
+    <form class="ga-form" novalidate>
+      <section class="ga-form__section">
+        <h2>Temel Bilgiler</h2>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="full_name">Ad Soyad<span class="text-danger">*</span></label>
+            <input id="full_name" name="full_name" type="text" required>
+          </div>
+          <div class="ga-form__group">
+            <label for="email">E-posta<span class="text-danger">*</span></label>
+            <input id="email" name="email" type="email" required>
+          </div>
+          <div class="ga-form__group">
+            <label for="phone">Telefon</label>
+            <input id="phone" name="phone" type="tel" placeholder="+90 5xx xxx xx xx">
+          </div>
+          <div class="ga-form__group">
+            <label for="location">Konum</label>
+            <input id="location" name="location" type="text" placeholder="Şehir, Ülke">
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Profesyonel Bilgiler</h2>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="linkedin">LinkedIn</label>
+            <input id="linkedin" name="linkedin" type="url" placeholder="https://www.linkedin.com/in/...">
+          </div>
+          <div class="ga-form__group">
+            <label for="portfolio">Portföy / GitHub</label>
+            <input id="portfolio" name="portfolio" type="url" placeholder="https://github.com/...">
+          </div>
+        </div>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="education_level">Eğitim Durumu</label>
+            <select id="education_level" name="education_level">
+              <option value="" selected disabled>Seçiniz</option>
+              <option value="lise">Lise</option>
+              <option value="on_lisans">Ön Lisans</option>
+              <option value="lisans">Lisans</option>
+              <option value="yuksek_lisans">Yüksek Lisans</option>
+              <option value="doktora">Doktora</option>
+            </select>
+          </div>
+          <div class="ga-form__group">
+            <label for="education_field">Mezuniyet Alanı</label>
+            <input id="education_field" name="education_field" type="text" placeholder="Bölüm">
+          </div>
+          <div class="ga-form__group">
+            <label for="graduation_year">Mezuniyet Yılı</label>
+            <input id="graduation_year" name="graduation_year" type="number" min="1950" max="2099" placeholder="2024">
+          </div>
+        </div>
+        <div class="ga-form__group">
+          <label for="experience_summary">İş Deneyimi</label>
+          <textarea id="experience_summary" name="experience_summary" rows="4" placeholder="Son pozisyonlarınızı ve görevlerinizi özetleyin."></textarea>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Teknik Yetenekler</h2>
+        <div class="ga-form__group">
+          <span class="d-block mb-2">Lütfen sahip olduğunuz yetenekleri seçiniz:</span>
+          <div class="ga-form__grid">
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="CAD"> CAD</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="Python"> Python</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="MATLAB"> MATLAB</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="PCB Design"> PCB Design</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="IoT Protokolleri"> IoT protokolleri</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="Diger"> Diğer</label>
+            </div>
+          </div>
+          <div class="ga-form__group">
+            <label for="skills_other">Diğer beceriler</label>
+            <input id="skills_other" name="skills_other" type="text" placeholder="Ek teknik yetenekler">
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Dil Yetenekleri</h2>
+        <div class="ga-form__group">
+          <label for="languages">Yabancı diller ve seviyeleri</label>
+          <input id="languages" name="languages" type="text" placeholder="Örn: İngilizce (C1), Almanca (B1)">
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Proje Deneyimleri</h2>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="project_one">Proje 1</label>
+            <textarea id="project_one" name="project_one" rows="4" placeholder="Proje kapsamı, rolünüz ve çıktılar"></textarea>
+          </div>
+          <div class="ga-form__group">
+            <label for="project_two">Proje 2</label>
+            <textarea id="project_two" name="project_two" rows="4" placeholder="Proje kapsamı, rolünüz ve çıktılar"></textarea>
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Kültürel &amp; Kişisel Sorular</h2>
+        <div class="ga-form__group">
+          <label for="why_greenairiva">GreenAiriva’yı neden tercih ediyorsunuz?</label>
+          <textarea id="why_greenairiva" name="why_greenairiva" rows="4"></textarea>
+        </div>
+        <div class="ga-form__group">
+          <label for="team_strength">Takım çalışmasında güçlü olduğunuz yön</label>
+          <textarea id="team_strength" name="team_strength" rows="3"></textarea>
+        </div>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="remote_fit">Uzaktan/Hibrit çalışmaya uygun musunuz?</label>
+            <input id="remote_fit" name="remote_fit" type="text" placeholder="Evet / Hayır ve açıklama">
+          </div>
+          <div class="ga-form__group">
+            <label for="travel">Seyahat engeliniz var mı?</label>
+            <input id="travel" name="travel" type="text" placeholder="Varsa detaylandırın">
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Referanslar</h2>
+        <div class="ga-form__group">
+          <h3>Referans 1</h3>
+          <div class="ga-form__grid">
+            <div class="ga-form__group">
+              <label for="ref1_name">Ad Soyad</label>
+              <input id="ref1_name" name="ref1_name" type="text">
+            </div>
+            <div class="ga-form__group">
+              <label for="ref1_relationship">İlişki</label>
+              <input id="ref1_relationship" name="ref1_relationship" type="text" placeholder="Örn: Eski Yönetici">
+            </div>
+            <div class="ga-form__group">
+              <label for="ref1_contact">İletişim</label>
+              <input id="ref1_contact" name="ref1_contact" type="text" placeholder="E-posta veya Telefon">
+            </div>
+          </div>
+        </div>
+        <div class="ga-form__group">
+          <h3>Referans 2</h3>
+          <div class="ga-form__grid">
+            <div class="ga-form__group">
+              <label for="ref2_name">Ad Soyad</label>
+              <input id="ref2_name" name="ref2_name" type="text">
+            </div>
+            <div class="ga-form__group">
+              <label for="ref2_relationship">İlişki</label>
+              <input id="ref2_relationship" name="ref2_relationship" type="text">
+            </div>
+            <div class="ga-form__group">
+              <label for="ref2_contact">İletişim</label>
+              <input id="ref2_contact" name="ref2_contact" type="text" placeholder="E-posta veya Telefon">
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Belgeler</h2>
+        <div class="ga-form__group">
+          <label for="cv">CV Yükleme<span class="text-danger">*</span></label>
+          <input id="cv" name="cv" type="file" required>
+        </div>
+        <div class="ga-form__group">
+          <label for="additional_documents">Ek belgeler / projeler</label>
+          <input id="additional_documents" name="additional_documents" type="file" multiple>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Onaylar</h2>
+        <div class="ga-form__group">
+          <label><input type="checkbox" name="kvkk" value="accepted" required> KVKK metnini okudum ve onaylıyorum.</label>
+        </div>
+        <div class="ga-form__group">
+          <label><input type="checkbox" name="email_opt_in" value="yes"> GreenAiriva bilgilendirme e-postası almak istiyorum.</label>
+        </div>
+      </section>
+    </form>
+  </main>
+</body>
+</html>

--- a/career/applications/apply3.html
+++ b/career/applications/apply3.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Yazılım &amp; Veri Mühendisi Başvuru Formu</title>
+</head>
+<body>
+  <main class="container my-5">
+    <header class="ga-form__group text-center">
+      <h1>Yazılım &amp; Veri Mühendisi</h1>
+      <p>GreenAiriva'nın yazılım ve veri altyapısını güçlendirmek için bu formu doldurun.</p>
+    </header>
+
+    <form class="ga-form" novalidate>
+      <section class="ga-form__section">
+        <h2>Temel Bilgiler</h2>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="full_name">Ad Soyad<span class="text-danger">*</span></label>
+            <input id="full_name" name="full_name" type="text" required>
+          </div>
+          <div class="ga-form__group">
+            <label for="email">E-posta<span class="text-danger">*</span></label>
+            <input id="email" name="email" type="email" required>
+          </div>
+          <div class="ga-form__group">
+            <label for="phone">Telefon</label>
+            <input id="phone" name="phone" type="tel" placeholder="+90 5xx xxx xx xx">
+          </div>
+          <div class="ga-form__group">
+            <label for="location">Konum</label>
+            <input id="location" name="location" type="text" placeholder="Şehir, Ülke">
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Profesyonel Bilgiler</h2>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="linkedin">LinkedIn</label>
+            <input id="linkedin" name="linkedin" type="url" placeholder="https://www.linkedin.com/in/...">
+          </div>
+          <div class="ga-form__group">
+            <label for="portfolio">Portföy / GitHub</label>
+            <input id="portfolio" name="portfolio" type="url" placeholder="https://github.com/...">
+          </div>
+        </div>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="education_level">Eğitim Durumu</label>
+            <select id="education_level" name="education_level">
+              <option value="" selected disabled>Seçiniz</option>
+              <option value="lise">Lise</option>
+              <option value="on_lisans">Ön Lisans</option>
+              <option value="lisans">Lisans</option>
+              <option value="yuksek_lisans">Yüksek Lisans</option>
+              <option value="doktora">Doktora</option>
+            </select>
+          </div>
+          <div class="ga-form__group">
+            <label for="education_field">Mezuniyet Alanı</label>
+            <input id="education_field" name="education_field" type="text" placeholder="Bölüm">
+          </div>
+          <div class="ga-form__group">
+            <label for="graduation_year">Mezuniyet Yılı</label>
+            <input id="graduation_year" name="graduation_year" type="number" min="1950" max="2099" placeholder="2024">
+          </div>
+        </div>
+        <div class="ga-form__group">
+          <label for="experience_summary">İş Deneyimi</label>
+          <textarea id="experience_summary" name="experience_summary" rows="4" placeholder="Son pozisyonlarınızı ve görevlerinizi özetleyin."></textarea>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Teknik Yetenekler</h2>
+        <div class="ga-form__group">
+          <span class="d-block mb-2">Lütfen sahip olduğunuz yetenekleri seçiniz:</span>
+          <div class="ga-form__grid">
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="CAD"> CAD</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="Python"> Python</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="MATLAB"> MATLAB</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="PCB Design"> PCB Design</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="IoT Protokolleri"> IoT protokolleri</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="Diger"> Diğer</label>
+            </div>
+          </div>
+          <div class="ga-form__group">
+            <label for="skills_other">Diğer beceriler</label>
+            <input id="skills_other" name="skills_other" type="text" placeholder="Ek teknik yetenekler">
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Dil Yetenekleri</h2>
+        <div class="ga-form__group">
+          <label for="languages">Yabancı diller ve seviyeleri</label>
+          <input id="languages" name="languages" type="text" placeholder="Örn: İngilizce (C1), Almanca (B1)">
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Proje Deneyimleri</h2>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="project_one">Proje 1</label>
+            <textarea id="project_one" name="project_one" rows="4" placeholder="Proje kapsamı, rolünüz ve çıktılar"></textarea>
+          </div>
+          <div class="ga-form__group">
+            <label for="project_two">Proje 2</label>
+            <textarea id="project_two" name="project_two" rows="4" placeholder="Proje kapsamı, rolünüz ve çıktılar"></textarea>
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Kültürel &amp; Kişisel Sorular</h2>
+        <div class="ga-form__group">
+          <label for="why_greenairiva">GreenAiriva’yı neden tercih ediyorsunuz?</label>
+          <textarea id="why_greenairiva" name="why_greenairiva" rows="4"></textarea>
+        </div>
+        <div class="ga-form__group">
+          <label for="team_strength">Takım çalışmasında güçlü olduğunuz yön</label>
+          <textarea id="team_strength" name="team_strength" rows="3"></textarea>
+        </div>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="remote_fit">Uzaktan/Hibrit çalışmaya uygun musunuz?</label>
+            <input id="remote_fit" name="remote_fit" type="text" placeholder="Evet / Hayır ve açıklama">
+          </div>
+          <div class="ga-form__group">
+            <label for="travel">Seyahat engeliniz var mı?</label>
+            <input id="travel" name="travel" type="text" placeholder="Varsa detaylandırın">
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Referanslar</h2>
+        <div class="ga-form__group">
+          <h3>Referans 1</h3>
+          <div class="ga-form__grid">
+            <div class="ga-form__group">
+              <label for="ref1_name">Ad Soyad</label>
+              <input id="ref1_name" name="ref1_name" type="text">
+            </div>
+            <div class="ga-form__group">
+              <label for="ref1_relationship">İlişki</label>
+              <input id="ref1_relationship" name="ref1_relationship" type="text" placeholder="Örn: Eski Yönetici">
+            </div>
+            <div class="ga-form__group">
+              <label for="ref1_contact">İletişim</label>
+              <input id="ref1_contact" name="ref1_contact" type="text" placeholder="E-posta veya Telefon">
+            </div>
+          </div>
+        </div>
+        <div class="ga-form__group">
+          <h3>Referans 2</h3>
+          <div class="ga-form__grid">
+            <div class="ga-form__group">
+              <label for="ref2_name">Ad Soyad</label>
+              <input id="ref2_name" name="ref2_name" type="text">
+            </div>
+            <div class="ga-form__group">
+              <label for="ref2_relationship">İlişki</label>
+              <input id="ref2_relationship" name="ref2_relationship" type="text">
+            </div>
+            <div class="ga-form__group">
+              <label for="ref2_contact">İletişim</label>
+              <input id="ref2_contact" name="ref2_contact" type="text" placeholder="E-posta veya Telefon">
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Belgeler</h2>
+        <div class="ga-form__group">
+          <label for="cv">CV Yükleme<span class="text-danger">*</span></label>
+          <input id="cv" name="cv" type="file" required>
+        </div>
+        <div class="ga-form__group">
+          <label for="additional_documents">Ek belgeler / projeler</label>
+          <input id="additional_documents" name="additional_documents" type="file" multiple>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Onaylar</h2>
+        <div class="ga-form__group">
+          <label><input type="checkbox" name="kvkk" value="accepted" required> KVKK metnini okudum ve onaylıyorum.</label>
+        </div>
+        <div class="ga-form__group">
+          <label><input type="checkbox" name="email_opt_in" value="yes"> GreenAiriva bilgilendirme e-postası almak istiyorum.</label>
+        </div>
+      </section>
+    </form>
+  </main>
+</body>
+</html>

--- a/career/applications/apply4.html
+++ b/career/applications/apply4.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Kimyager / Malzeme Bilim Uzmanı Başvuru Formu</title>
+</head>
+<body>
+  <main class="container my-5">
+    <header class="ga-form__group text-center">
+      <h1>Kimyager / Malzeme Bilim Uzmanı</h1>
+      <p>GreenAiriva'nın malzeme ve kimya araştırmalarında görev almak için bu formu doldurun.</p>
+    </header>
+
+    <form class="ga-form" novalidate>
+      <section class="ga-form__section">
+        <h2>Temel Bilgiler</h2>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="full_name">Ad Soyad<span class="text-danger">*</span></label>
+            <input id="full_name" name="full_name" type="text" required>
+          </div>
+          <div class="ga-form__group">
+            <label for="email">E-posta<span class="text-danger">*</span></label>
+            <input id="email" name="email" type="email" required>
+          </div>
+          <div class="ga-form__group">
+            <label for="phone">Telefon</label>
+            <input id="phone" name="phone" type="tel" placeholder="+90 5xx xxx xx xx">
+          </div>
+          <div class="ga-form__group">
+            <label for="location">Konum</label>
+            <input id="location" name="location" type="text" placeholder="Şehir, Ülke">
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Profesyonel Bilgiler</h2>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="linkedin">LinkedIn</label>
+            <input id="linkedin" name="linkedin" type="url" placeholder="https://www.linkedin.com/in/...">
+          </div>
+          <div class="ga-form__group">
+            <label for="portfolio">Portföy / GitHub</label>
+            <input id="portfolio" name="portfolio" type="url" placeholder="https://github.com/...">
+          </div>
+        </div>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="education_level">Eğitim Durumu</label>
+            <select id="education_level" name="education_level">
+              <option value="" selected disabled>Seçiniz</option>
+              <option value="lise">Lise</option>
+              <option value="on_lisans">Ön Lisans</option>
+              <option value="lisans">Lisans</option>
+              <option value="yuksek_lisans">Yüksek Lisans</option>
+              <option value="doktora">Doktora</option>
+            </select>
+          </div>
+          <div class="ga-form__group">
+            <label for="education_field">Mezuniyet Alanı</label>
+            <input id="education_field" name="education_field" type="text" placeholder="Bölüm">
+          </div>
+          <div class="ga-form__group">
+            <label for="graduation_year">Mezuniyet Yılı</label>
+            <input id="graduation_year" name="graduation_year" type="number" min="1950" max="2099" placeholder="2024">
+          </div>
+        </div>
+        <div class="ga-form__group">
+          <label for="experience_summary">İş Deneyimi</label>
+          <textarea id="experience_summary" name="experience_summary" rows="4" placeholder="Son pozisyonlarınızı ve görevlerinizi özetleyin."></textarea>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Teknik Yetenekler</h2>
+        <div class="ga-form__group">
+          <span class="d-block mb-2">Lütfen sahip olduğunuz yetenekleri seçiniz:</span>
+          <div class="ga-form__grid">
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="CAD"> CAD</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="Python"> Python</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="MATLAB"> MATLAB</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="PCB Design"> PCB Design</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="IoT Protokolleri"> IoT protokolleri</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="Diger"> Diğer</label>
+            </div>
+          </div>
+          <div class="ga-form__group">
+            <label for="skills_other">Diğer beceriler</label>
+            <input id="skills_other" name="skills_other" type="text" placeholder="Ek teknik yetenekler">
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Dil Yetenekleri</h2>
+        <div class="ga-form__group">
+          <label for="languages">Yabancı diller ve seviyeleri</label>
+          <input id="languages" name="languages" type="text" placeholder="Örn: İngilizce (C1), Almanca (B1)">
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Proje Deneyimleri</h2>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="project_one">Proje 1</label>
+            <textarea id="project_one" name="project_one" rows="4" placeholder="Proje kapsamı, rolünüz ve çıktılar"></textarea>
+          </div>
+          <div class="ga-form__group">
+            <label for="project_two">Proje 2</label>
+            <textarea id="project_two" name="project_two" rows="4" placeholder="Proje kapsamı, rolünüz ve çıktılar"></textarea>
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Kültürel &amp; Kişisel Sorular</h2>
+        <div class="ga-form__group">
+          <label for="why_greenairiva">GreenAiriva’yı neden tercih ediyorsunuz?</label>
+          <textarea id="why_greenairiva" name="why_greenairiva" rows="4"></textarea>
+        </div>
+        <div class="ga-form__group">
+          <label for="team_strength">Takım çalışmasında güçlü olduğunuz yön</label>
+          <textarea id="team_strength" name="team_strength" rows="3"></textarea>
+        </div>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="remote_fit">Uzaktan/Hibrit çalışmaya uygun musunuz?</label>
+            <input id="remote_fit" name="remote_fit" type="text" placeholder="Evet / Hayır ve açıklama">
+          </div>
+          <div class="ga-form__group">
+            <label for="travel">Seyahat engeliniz var mı?</label>
+            <input id="travel" name="travel" type="text" placeholder="Varsa detaylandırın">
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Referanslar</h2>
+        <div class="ga-form__group">
+          <h3>Referans 1</h3>
+          <div class="ga-form__grid">
+            <div class="ga-form__group">
+              <label for="ref1_name">Ad Soyad</label>
+              <input id="ref1_name" name="ref1_name" type="text">
+            </div>
+            <div class="ga-form__group">
+              <label for="ref1_relationship">İlişki</label>
+              <input id="ref1_relationship" name="ref1_relationship" type="text" placeholder="Örn: Eski Yönetici">
+            </div>
+            <div class="ga-form__group">
+              <label for="ref1_contact">İletişim</label>
+              <input id="ref1_contact" name="ref1_contact" type="text" placeholder="E-posta veya Telefon">
+            </div>
+          </div>
+        </div>
+        <div class="ga-form__group">
+          <h3>Referans 2</h3>
+          <div class="ga-form__grid">
+            <div class="ga-form__group">
+              <label for="ref2_name">Ad Soyad</label>
+              <input id="ref2_name" name="ref2_name" type="text">
+            </div>
+            <div class="ga-form__group">
+              <label for="ref2_relationship">İlişki</label>
+              <input id="ref2_relationship" name="ref2_relationship" type="text">
+            </div>
+            <div class="ga-form__group">
+              <label for="ref2_contact">İletişim</label>
+              <input id="ref2_contact" name="ref2_contact" type="text" placeholder="E-posta veya Telefon">
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Belgeler</h2>
+        <div class="ga-form__group">
+          <label for="cv">CV Yükleme<span class="text-danger">*</span></label>
+          <input id="cv" name="cv" type="file" required>
+        </div>
+        <div class="ga-form__group">
+          <label for="additional_documents">Ek belgeler / projeler</label>
+          <input id="additional_documents" name="additional_documents" type="file" multiple>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Onaylar</h2>
+        <div class="ga-form__group">
+          <label><input type="checkbox" name="kvkk" value="accepted" required> KVKK metnini okudum ve onaylıyorum.</label>
+        </div>
+        <div class="ga-form__group">
+          <label><input type="checkbox" name="email_opt_in" value="yes"> GreenAiriva bilgilendirme e-postası almak istiyorum.</label>
+        </div>
+      </section>
+    </form>
+  </main>
+</body>
+</html>

--- a/career/applications/apply5.html
+++ b/career/applications/apply5.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>İş Geliştirme &amp; Fon Bulma Sorumlusu Başvuru Formu</title>
+</head>
+<body>
+  <main class="container my-5">
+    <header class="ga-form__group text-center">
+      <h1>İş Geliştirme &amp; Fon Bulma Sorumlusu</h1>
+      <p>GreenAiriva'nın büyüme ve fon bulma girişimlerini desteklemek için bu formu doldurun.</p>
+    </header>
+
+    <form class="ga-form" novalidate>
+      <section class="ga-form__section">
+        <h2>Temel Bilgiler</h2>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="full_name">Ad Soyad<span class="text-danger">*</span></label>
+            <input id="full_name" name="full_name" type="text" required>
+          </div>
+          <div class="ga-form__group">
+            <label for="email">E-posta<span class="text-danger">*</span></label>
+            <input id="email" name="email" type="email" required>
+          </div>
+          <div class="ga-form__group">
+            <label for="phone">Telefon</label>
+            <input id="phone" name="phone" type="tel" placeholder="+90 5xx xxx xx xx">
+          </div>
+          <div class="ga-form__group">
+            <label for="location">Konum</label>
+            <input id="location" name="location" type="text" placeholder="Şehir, Ülke">
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Profesyonel Bilgiler</h2>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="linkedin">LinkedIn</label>
+            <input id="linkedin" name="linkedin" type="url" placeholder="https://www.linkedin.com/in/...">
+          </div>
+          <div class="ga-form__group">
+            <label for="portfolio">Portföy / GitHub</label>
+            <input id="portfolio" name="portfolio" type="url" placeholder="https://github.com/...">
+          </div>
+        </div>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="education_level">Eğitim Durumu</label>
+            <select id="education_level" name="education_level">
+              <option value="" selected disabled>Seçiniz</option>
+              <option value="lise">Lise</option>
+              <option value="on_lisans">Ön Lisans</option>
+              <option value="lisans">Lisans</option>
+              <option value="yuksek_lisans">Yüksek Lisans</option>
+              <option value="doktora">Doktora</option>
+            </select>
+          </div>
+          <div class="ga-form__group">
+            <label for="education_field">Mezuniyet Alanı</label>
+            <input id="education_field" name="education_field" type="text" placeholder="Bölüm">
+          </div>
+          <div class="ga-form__group">
+            <label for="graduation_year">Mezuniyet Yılı</label>
+            <input id="graduation_year" name="graduation_year" type="number" min="1950" max="2099" placeholder="2024">
+          </div>
+        </div>
+        <div class="ga-form__group">
+          <label for="experience_summary">İş Deneyimi</label>
+          <textarea id="experience_summary" name="experience_summary" rows="4" placeholder="Son pozisyonlarınızı ve görevlerinizi özetleyin."></textarea>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Teknik Yetenekler</h2>
+        <div class="ga-form__group">
+          <span class="d-block mb-2">Lütfen sahip olduğunuz yetenekleri seçiniz:</span>
+          <div class="ga-form__grid">
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="CAD"> CAD</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="Python"> Python</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="MATLAB"> MATLAB</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="PCB Design"> PCB Design</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="IoT Protokolleri"> IoT protokolleri</label>
+            </div>
+            <div class="ga-form__group">
+              <label><input type="checkbox" name="skills[]" value="Diger"> Diğer</label>
+            </div>
+          </div>
+          <div class="ga-form__group">
+            <label for="skills_other">Diğer beceriler</label>
+            <input id="skills_other" name="skills_other" type="text" placeholder="Ek teknik yetenekler">
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Dil Yetenekleri</h2>
+        <div class="ga-form__group">
+          <label for="languages">Yabancı diller ve seviyeleri</label>
+          <input id="languages" name="languages" type="text" placeholder="Örn: İngilizce (C1), Almanca (B1)">
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Proje Deneyimleri</h2>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="project_one">Proje 1</label>
+            <textarea id="project_one" name="project_one" rows="4" placeholder="Proje kapsamı, rolünüz ve çıktılar"></textarea>
+          </div>
+          <div class="ga-form__group">
+            <label for="project_two">Proje 2</label>
+            <textarea id="project_two" name="project_two" rows="4" placeholder="Proje kapsamı, rolünüz ve çıktılar"></textarea>
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Kültürel &amp; Kişisel Sorular</h2>
+        <div class="ga-form__group">
+          <label for="why_greenairiva">GreenAiriva’yı neden tercih ediyorsunuz?</label>
+          <textarea id="why_greenairiva" name="why_greenairiva" rows="4"></textarea>
+        </div>
+        <div class="ga-form__group">
+          <label for="team_strength">Takım çalışmasında güçlü olduğunuz yön</label>
+          <textarea id="team_strength" name="team_strength" rows="3"></textarea>
+        </div>
+        <div class="ga-form__grid">
+          <div class="ga-form__group">
+            <label for="remote_fit">Uzaktan/Hibrit çalışmaya uygun musunuz?</label>
+            <input id="remote_fit" name="remote_fit" type="text" placeholder="Evet / Hayır ve açıklama">
+          </div>
+          <div class="ga-form__group">
+            <label for="travel">Seyahat engeliniz var mı?</label>
+            <input id="travel" name="travel" type="text" placeholder="Varsa detaylandırın">
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Referanslar</h2>
+        <div class="ga-form__group">
+          <h3>Referans 1</h3>
+          <div class="ga-form__grid">
+            <div class="ga-form__group">
+              <label for="ref1_name">Ad Soyad</label>
+              <input id="ref1_name" name="ref1_name" type="text">
+            </div>
+            <div class="ga-form__group">
+              <label for="ref1_relationship">İlişki</label>
+              <input id="ref1_relationship" name="ref1_relationship" type="text" placeholder="Örn: Eski Yönetici">
+            </div>
+            <div class="ga-form__group">
+              <label for="ref1_contact">İletişim</label>
+              <input id="ref1_contact" name="ref1_contact" type="text" placeholder="E-posta veya Telefon">
+            </div>
+          </div>
+        </div>
+        <div class="ga-form__group">
+          <h3>Referans 2</h3>
+          <div class="ga-form__grid">
+            <div class="ga-form__group">
+              <label for="ref2_name">Ad Soyad</label>
+              <input id="ref2_name" name="ref2_name" type="text">
+            </div>
+            <div class="ga-form__group">
+              <label for="ref2_relationship">İlişki</label>
+              <input id="ref2_relationship" name="ref2_relationship" type="text">
+            </div>
+            <div class="ga-form__group">
+              <label for="ref2_contact">İletişim</label>
+              <input id="ref2_contact" name="ref2_contact" type="text" placeholder="E-posta veya Telefon">
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Belgeler</h2>
+        <div class="ga-form__group">
+          <label for="cv">CV Yükleme<span class="text-danger">*</span></label>
+          <input id="cv" name="cv" type="file" required>
+        </div>
+        <div class="ga-form__group">
+          <label for="additional_documents">Ek belgeler / projeler</label>
+          <input id="additional_documents" name="additional_documents" type="file" multiple>
+        </div>
+      </section>
+
+      <section class="ga-form__section">
+        <h2>Onaylar</h2>
+        <div class="ga-form__group">
+          <label><input type="checkbox" name="kvkk" value="accepted" required> KVKK metnini okudum ve onaylıyorum.</label>
+        </div>
+        <div class="ga-form__group">
+          <label><input type="checkbox" name="email_opt_in" value="yes"> GreenAiriva bilgilendirme e-postası almak istiyorum.</label>
+        </div>
+      </section>
+    </form>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated static application forms for the five advertised roles with consistent layout sections for candidate information, experience, and supporting details
- ensure each form provides the required technical skills checkboxes, project inputs, cultural questions, reference fields, document uploads, and consent confirmations without submission actions

## Testing
- not run (static HTML changes)


------
https://chatgpt.com/codex/tasks/task_e_68d31fb9abb0832e863570220596a736